### PR TITLE
Update for 2016.3.x changes

### DIFF
--- a/rdp/map.jinja
+++ b/rdp/map.jinja
@@ -9,6 +9,7 @@
   key:values here that differ from whats in defaults.yml
 ##}
 {% set osrelease_map = salt['grains.filter_by']({
+    '2012ServerR2': {},
     '2012Server': {},
     '2008ServerR2': {},
   }

--- a/rdp/registry.sls
+++ b/rdp/registry.sls
@@ -18,7 +18,6 @@ rdp-nla-registry:
     - vname: UserAuthentication
     - vdata: {{ lookup.registry.get(rdp.nla_enabled) }}
     - vtype: REG_DWORD
-    - reflection: False
 
 {##
   Changing the TCP port number requires a system restart. 
@@ -31,5 +30,3 @@ rdp-port-registry:
     - vname: PortNumber
     - vdata: {{ rdp.tcp_port }}
     - vtype: REG_DWORD
-    - reflection: False
-


### PR DESCRIPTION
**Summary**
- Add 2012ServerR2 to map.jinja to account for changes to the osrelease grain coming in 2016.3.x.
- Remove the reflection parameter of [_reg.present_](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.reg.html) (deprecated since version 2015.8.2). Since the registry entries weren't under the Software key, these parameters were superfluous and had no effect anyway.
